### PR TITLE
Fix typo related to format when showing results for Bayesian inference

### DIFF
--- a/1.5-spam-classifier/Bayesian_Inference.ipynb
+++ b/1.5-spam-classifier/Bayesian_Inference.ipynb
@@ -722,7 +722,7 @@
     "\n",
     "# P(Pos)\n",
     "p_pos = # TODO\n",
-    "print('The probability of getting a positive test result P(Pos) is: {}',format(p_pos))"
+    "print('The probability of getting a positive test result P(Pos) is: {}'.format(p_pos))"
    ]
   },
   {

--- a/1.5-spam-classifier/Bayesian_Inference_solution.ipynb
+++ b/1.5-spam-classifier/Bayesian_Inference_solution.ipynb
@@ -1008,7 +1008,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The probability of getting a positive test result P(Pos) is: {} 0.10799999999999998\n"
+      "The probability of getting a positive test result P(Pos) is: 0.10799999999999998\n"
      ]
     }
    ],


### PR DESCRIPTION
- Updated print line when showing Bayesian inference results on diabetes example